### PR TITLE
Added overriding parent query builder first method to use collection to get first result

### DIFF
--- a/src/Mmanos/Metable/QueryBuilder.php
+++ b/src/Mmanos/Metable/QueryBuilder.php
@@ -485,6 +485,19 @@ class QueryBuilder extends Builder
 	}
 	
 	/**
+	 * Execute the query and get the first result.
+	 *
+	 * @param  array   $columns
+	 * @return mixed|\Illuminate\Database\Eloquent\Collection|static
+	 */
+	public function first($columns = array('*'))
+	{
+		$results = $this->take(1)->get($columns);
+
+		return count($results) > 0 ? $results->first() : null;
+	}
+	
+	/**
 	 * Get a paginator for the "select" statement.
 	 *
 	 * @param  int    $perPage


### PR DESCRIPTION
This package overrides Eloquent query builder and uses collections and so the parent first method did not support collections and was doing reset on an array.
